### PR TITLE
Fix var dir permissions

### DIFF
--- a/cmd/local/install.go
+++ b/cmd/local/install.go
@@ -108,7 +108,7 @@ func initVarDir() error {
 		return err
 	}
 
-	for _, dir := range []string{"manifests", "storage", "registry"} {
+	for _, dir := range []string{"storage", "registry"} {
 		fullPath := path.Join(VAR_DIR, dir)
 		_, err := os.Stat(fullPath)
 		if os.IsNotExist(err) {

--- a/cmd/local/install.go
+++ b/cmd/local/install.go
@@ -113,7 +113,7 @@ func initVarDir() error {
 		_, err := os.Stat(fullPath)
 		if os.IsNotExist(err) {
 			log.Printf("Creating directory: %s", fullPath)
-			if err := os.MkdirAll(fullPath, 777); err != nil {
+			if err := os.MkdirAll(fullPath, 0777); err != nil {
 				return err
 			}
 		} else if err != nil {


### PR DESCRIPTION
Apperantly, the "permissions bits" needed to be prefixed with `0` to signal octal